### PR TITLE
Update SSL version to TLS 1.2

### DIFF
--- a/lib/deluge/protocol/v3.rb
+++ b/lib/deluge/protocol/v3.rb
@@ -22,7 +22,7 @@ class Deluge
       connection = TCPSocket.new(host, port)
       ctx = OpenSSL::SSL::SSLContext.new
       ctx.set_params(verify_mode: OpenSSL::SSL::VERIFY_NONE)
-      ctx.ssl_version = :SSLv3
+      ctx.ssl_version = :TLSv1_2
 
       @con = OpenSSL::SSL::SSLSocket.new(connection, ctx)
       @con.connect


### PR DESCRIPTION
SSLv2/3 is now disabled in Debian/Ubuntu, so connections to the Deluge daemon fail with SSL errors.  Setting the connection to use the latest TLS version (which deluge supports fully) resolves the problem.

This is also a contender for the smallest pull request you'll ever see!