### PR TITLE
New implementation for handle_new_data that utilises buffering.

### DIFF
--- a/lib/deluge/protocol/v3.rb
+++ b/lib/deluge/protocol/v3.rb
@@ -38,7 +38,6 @@ class Deluge
             end
 
             handle_new_data(data.bytes)
-
           rescue Exception => e
             puts e.message
             p e.backtrace
@@ -122,23 +121,15 @@ class Deluge
 
     private
 
-    def handle_new_data data, &block
-      # commented code is for version 4, not yet supported
-  #    @buffer.concat(data)
-  #
-  #    while @buffer.length >= 5 # 'D' + 4 byte integer
-  #      if @message_length == 0
-  #        handle_new_message
-  #      end
-  #
-  #      if @buffer.length >= @message_length
-  #        message = @buffer.shift(@message_length)
-  #        @message_length = 0
-  #
-          message = data
-          handle_complete_message(message)
-  #      end
-  #    end
+    def handle_new_data data
+      @buffer.push(*data)
+
+      begin
+        handle_complete_message(@buffer)
+        @buffer = []
+      rescue Exception
+        # Do nothing -- @buffer stays the same implicitly
+      end
     end
 
   #  def handle_new_message


### PR DESCRIPTION
Previously 1024 byte messages were read and that was used for the entire message. Calls that potentially return a huge response (e.g. `'core.get_torrents_status', {}, []`) can go well beyond 1024 bytes.

This uses the unused `@buffer` to implement buffering on received messages.